### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 ![GitHub](https://img.shields.io/github/license/VoxCrafterLP/JumpRace)
 ![GitHub milestone](https://img.shields.io/github/milestones/progress/VoxCrafterLP/JumpRace/4)
 ![MV version](https://img.shields.io/badge/Minecraft%20version-1.8.x-brightgreen)
+![bStats Servers](https://img.shields.io/bstats/servers/11049)
 
-This is a spigot based jumpandrun minigame. It's almost like the gamemode 'JumpLeague' on the gommehd.net server but with a few changes. The plugin contains its own building system, which can be used to build your own modules.
+This is a spigot based Jump 'n' Run minigame. It's almost like the gamemode 'JumpLeague' on the GommeHD.net server but with a few changes. The plugin contains its own building system, which can be used to build your own modules.
 
-**Important**! It is highly recommended to use this plugin in a cloud-system based environment like [CloudNET](https://cloudnetservice.eu/). 
+**Important**! It is highly recommended using this plugin in a cloud-system based environment like [CloudNET](https://cloudnetservice.eu/). 
 
 ## Features
 
@@ -25,14 +26,14 @@ This is a spigot based jumpandrun minigame. It's almost like the gamemode 'JumpL
 
 ## Installation
 
-This plugin only requires a properly set up spigot server, but it's recommended to use the latest build of the 1.8.8.
-You can learn here how to use the [latest build](https://www.spigotmc.org/wiki/buildtools/#1-8-8).
+This plugin only requires a properly set up Spigot server, but it's recommended to use the latest build of version 1.8.8.
+You can learn how to use the latest build [here](https://www.spigotmc.org/wiki/buildtools/#1-8-8).
 
 1. Download the latest JAR file from the [releases tab](https://github.com/VoxCrafterLP/JumpRace/releases).
-2. Move the JAR file into your plugins folder.
+2. Move the JAR file into your `plugins` folder.
 3. Restart your server.
 4. Check the console to ensure that the plugin is working properly.
-5. Locate and open the config file in `/plugins/JumpRace/config.yml`.
+5. Locate and open the config file in `plugins/JumpRace/config.yml`.
 6. Configure the plugin to your needs.
 7. Have fun!
 
@@ -41,7 +42,6 @@ You can learn here how to use the [latest build](https://www.spigotmc.org/wiki/b
 ### Maven dependency
 
 ```xml
-
 <dependency>
   <groupId>com.voxcrafterlp</groupId>
   <artifactId>JumpRace</artifactId>
@@ -101,12 +101,12 @@ At the moment these languages are available:
 - de_CH (Swiss German)
 ```
 
-If you want to add your own language file, you can copy an existing translation file from the `/plugins/JumpRace/languages` folder and translate it. 
+If you want to add your own language file, you can copy an existing translation file from the `plugins/JumpRace/languages` folder and translate it. 
 **Important! You have to encode the translation file in ISO-8859-1.**
-To enable the translation, you have to switch the language file in the config.
+To enable the translation, you have to change the language file in the config.
 
 
-## Contributers
+## Contributors
 
 - [MakeItGame](https://www.youtube.com/channel/UCk8ROONMzJ3wlZ66vyyffJg) (German translation)
 - [Lezurex](https://github.com/Lezurex) (Swiss German translation)


### PR DESCRIPTION
Improved readme with some typos and small changes

# Changes

- Line 8: Visitors can now see the popularity of this plugin.
- Line 10: Stylised the word "Jump 'n' Run" better and more correct. Added capitalized letters to GommeHD.net for more style.
- Line 12: "Using" is more grammatically correct.
- Line 29: "Spigot" is a name and therefore has to be written with a capital. Replaced "the" with "version" for a more clear understanding.
- Line 30: Improved sentence structure. Here is now the link, a call-to-action.
- Line 33: Styled the folder name accordingly.
- Line 36: The plugins folder is not located at the UNIX system root. Therefore I removed the first slash.
- Line 44/45: Removed unnessecary blank line. It will be rendered in IntelliJ but not on Github.
- Line 104: Removed first slash of path. See explanation of Line 36.
- Line 106: "Switch" is just not suitable.
- Line 109: Spelling issue.